### PR TITLE
[DT-040954] Github Module: The Microsoft365.Exchange module is not showing the Microsoft365.Common module as a dependency on its details for issue number 1 in the reopen

### DIFF
--- a/Module.Build.json
+++ b/Module.Build.json
@@ -20,5 +20,6 @@
     },
     "Version": "9.0.0",
     "ImagePath": "./image.png",
-    "Description": "The Microsoft 365 Common module provides API integrations and various tools required for other Microsoft 365 modules to function."
+    "Description": "The Microsoft 365 Common module provides API integrations and various tools required for other Microsoft 365 modules to function.",
+	"HideInFeaturesList": true
 }


### PR DESCRIPTION
Fixes the following:
2. Microsoft365.Common module is present on the feature page unlike the message queue module is (V9 and V8)
3. The Microsoft365.Common module can be picked as a dependency for a project (V9)

Other issues raised were determined to be platform issues and not module-specific.